### PR TITLE
Update pretrained.jl with CIFAR10 functionality

### DIFF
--- a/src/models/pretrained.jl
+++ b/src/models/pretrained.jl
@@ -47,7 +47,7 @@ function load_cifar10_mlp()
 end
 
 function load_cifar10_ensemble()
-    M = deserialize(joinpath(vision_dir, "cifar_10_ensemble.jls.jls"))
+    M = deserialize(joinpath(vision_dir, "cifar_10_ensemble.jls"))
     return M
 end
 

--- a/src/models/pretrained.jl
+++ b/src/models/pretrained.jl
@@ -41,12 +41,12 @@ function load_fashion_mnist_vae(; strong=true)
     return vae
 end
 
-function load_cifar10_mlp()
+function load_cifar_10_mlp()
     M = deserialize(joinpath(vision_dir, "cifar_10_mlp.jls"))
     return M
 end
 
-function load_cifar10_ensemble()
+function load_cifar_10_ensemble()
     M = deserialize(joinpath(vision_dir, "cifar_10_ensemble.jls"))
     return M
 end

--- a/src/models/pretrained.jl
+++ b/src/models/pretrained.jl
@@ -40,3 +40,22 @@ function load_fashion_mnist_vae(; strong=true)
     end
     return vae
 end
+
+function load_cifar10_mlp()
+    M = deserialize(joinpath(vision_dir, "cifar_10_mlp.jls"))
+    return M
+end
+
+function load_cifar10_ensemble()
+    M = deserialize(joinpath(vision_dir, "cifar_10_ensemble.jls.jls"))
+    return M
+end
+
+function load_cifar_10_vae(; strong=true)
+    if strong
+        vae = deserialize(joinpath(vision_dir, "cifar_10_vae_strong.jls"))
+    else
+        vae = deserialize(joinpath(vision_dir, "cifar_10_vae_weak.jls"))
+    end
+    return vae
+end


### PR DESCRIPTION
It turns out we missed one important bit when implementing CIFAR10 dataset. Namely, we forgot to add functionality which allows the user to load pre-trained models with the newly implemented dataset.