### PR TITLE
add `codecov.yml` file

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,8 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 80%    # the required coverage value
+        threshold: 0.01%  # the leniency in hitting the target
+  ignore:
+  - "src/**/visualization/**/*"


### PR DESCRIPTION
- ignores `visualization` folders, which are related to printing and plotting as they are not part of the "core" functionality of the package
- enforces a 80% code coverage to pass the pipeline