### PR TITLE
Enable support for `kw::Symbol` in parallelizable functions

### DIFF
--- a/docs/src/tutorials/parallelization.qmd
+++ b/docs/src/tutorials/parallelization.qmd
@@ -56,7 +56,8 @@ ces = @with_parallelizer parallelizer begin
         target,
         counterfactual_data,
         M,
-        generator
+        generator;
+        decision_threshold=0.9
     )
 end
 ```

--- a/docs/src/tutorials/parallelization.qmd
+++ b/docs/src/tutorials/parallelization.qmd
@@ -56,8 +56,7 @@ ces = @with_parallelizer parallelizer begin
         target,
         counterfactual_data,
         M,
-        generator;
-        decision_threshold=0.9
+        generator
     )
 end
 ```

--- a/ext/MPIExt.jl
+++ b/ext/MPIExt.jl
@@ -80,7 +80,6 @@ function CounterfactualExplanations.parallelize(
     args...;
     kwargs...,
 )
-    @assert CounterfactualExplanations.parallelizable(f) "`f` is not a parallelizable process."
 
     # Extract positional arguments:
     counterfactuals = args[1] |> x -> CounterfactualExplanations.vectorize_collection(x)
@@ -143,7 +142,6 @@ function CounterfactualExplanations.parallelize(
     args...;
     kwargs...,
 )
-    @assert CounterfactualExplanations.parallelizable(f) "`f` is not a parallelizable process."
 
     # Setup:
     counterfactuals = args[1] |> x -> CounterfactualExplanations.vectorize_collection(x)

--- a/src/parallelization/Parallelization.jl
+++ b/src/parallelization/Parallelization.jl
@@ -1,6 +1,6 @@
 module Parallelization
 
-export @with_parallelizer, ThreadsParallelizer
+export @with_parallelizer, with_parallelizer, ThreadsParallelizer
 
 import ..CounterfactualExplanations
 using CounterfactualExplanations: generate_counterfactual
@@ -43,8 +43,9 @@ macro with_parallelizer(parallelizer, expr)
     # Parallelize:
     output = quote
         @assert CounterfactualExplanations.parallelizable($f) "`f` is not a parallelizable process."
+        kws = [Pair(k,typeof(v) == QuoteNode ? eval(v) : v) for (k,v) in $aakws]
         output = CounterfactualExplanations.parallelize(
-            $pllr, $f, $escaped_args...; $aakws...
+            $pllr, $f, $escaped_args...; kws...
         )
         output
     end
@@ -52,3 +53,5 @@ macro with_parallelizer(parallelizer, expr)
 end
 
 end
+
+

--- a/src/parallelization/Parallelization.jl
+++ b/src/parallelization/Parallelization.jl
@@ -14,7 +14,7 @@ include("threads.jl")
 This macro can be used to parallelize a function call or block of code. The macro will check that the function is parallelizable and then call `parallelize` with the supplied `parallelizer` and `expr`.
 """
 macro with_parallelizer(parallelizer, expr)
-    if !(expr.head ∈ (:block, :call)) 
+    if !(expr.head ∈ (:block, :call))
         throw(AssertionError("Expected a block or function call."))
     end
     if expr.head == :block
@@ -50,7 +50,9 @@ macro with_parallelizer(parallelizer, expr)
         if !CounterfactualExplanations.parallelizable($f)
             throw(AssertionError("$(f) is not a parallelizable process."))
         end
-        output = CounterfactualExplanations.parallelize($pllr, $f, $escaped_args...; $aakws...)
+        output = CounterfactualExplanations.parallelize(
+            $pllr, $f, $escaped_args...; $aakws...
+        )
         output
     end
     return output

--- a/src/parallelization/Parallelization.jl
+++ b/src/parallelization/Parallelization.jl
@@ -43,15 +43,11 @@ macro with_parallelizer(parallelizer, expr)
     # Parallelize:
     output = quote
         @assert CounterfactualExplanations.parallelizable($f) "`f` is not a parallelizable process."
-        kws = [Pair(k,typeof(v) == QuoteNode ? eval(v) : v) for (k,v) in $aakws]
-        output = CounterfactualExplanations.parallelize(
-            $pllr, $f, $escaped_args...; kws...
-        )
+        kws = [Pair(k, typeof(v) == QuoteNode ? eval(v) : v) for (k, v) in $aakws]
+        output = CounterfactualExplanations.parallelize($pllr, $f, $escaped_args...; kws...)
         output
     end
     return output
 end
 
 end
-
-


### PR DESCRIPTION
this is working but very unsure about whether it's safe to call eval