### PR TITLE
Fix deprecation functionality

### DIFF
--- a/src/CounterfactualExplanations.jl
+++ b/src/CounterfactualExplanations.jl
@@ -102,4 +102,6 @@ include("assign_traits.jl")
 # Expose necessary functions from extensions:
 include("extensions/extensions.jl")
 
+include("deprecated.jl")
+
 end


### PR DESCRIPTION
Thanks to #369 I noticed that deprecation functionality is not working as expected. It turned out `deprecated.jl` file was not included in the main module. Now, thanks to this small fix, it works as expected and informs user about the deprecation:

```
julia> using CounterfactualExplanations

julia> CounterfactualExplanations.PyTorchModel()
ERROR: PyTorchModel has been moved to the package TaijaInteroperability.jl.
Run `Pkg.add("TaijaInteroperability")` to install it, restart Julia,
and then run `using TaijaInteroperability` to load it.
```