### PR TITLE
Remove redundant code from the `counterfactuals` folder

### DIFF
--- a/src/convergence/decision_threshold.jl
+++ b/src/convergence/decision_threshold.jl
@@ -4,6 +4,15 @@ Base.@kwdef struct DecisionThresholdConvergence <: AbstractConvergence
     min_success_rate::AbstractFloat = 0.75
 end
 
+function DecisionThresholdConvergence(;
+    decision_threshold::AbstractFloat=0.5,
+    max_iter::Int=100,
+    min_success_rate::AbstractFloat=0.75,
+)
+    @assert 0.0 < min_success_rate <= 1.0 "Minimum success rate should be ∈ [0.0,1.0]."
+    return DecisionThresholdConvergence(decision_threshold, max_iter, min_success_rate)
+end
+
 """
     converged(convergence::DecisionThresholdConvergence, ce::CounterfactualExplanation)
 

--- a/src/convergence/decision_threshold.jl
+++ b/src/convergence/decision_threshold.jl
@@ -1,7 +1,7 @@
-Base.@kwdef struct DecisionThresholdConvergence <: AbstractConvergence
-    decision_threshold::AbstractFloat = 0.5
-    max_iter::Int = 100
-    min_success_rate::AbstractFloat = 0.75
+struct DecisionThresholdConvergence <: AbstractConvergence
+    decision_threshold::AbstractFloat
+    max_iter::Int
+    min_success_rate::AbstractFloat
 end
 
 function DecisionThresholdConvergence(;

--- a/src/convergence/generator_conditions.jl
+++ b/src/convergence/generator_conditions.jl
@@ -1,8 +1,8 @@
-Base.@kwdef struct GeneratorConditionsConvergence <: AbstractConvergence
-    decision_threshold::AbstractFloat = 0.5
-    gradient_tol::AbstractFloat = 1e-2
-    max_iter::Int = 100
-    min_success_rate::AbstractFloat = 0.75
+struct GeneratorConditionsConvergence <: AbstractConvergence
+    decision_threshold::AbstractFloat
+    gradient_tol::AbstractFloat
+    max_iter::Int
+    min_success_rate::AbstractFloat
 end
 
 function GeneratorConditionsConvergence(;

--- a/src/convergence/generator_conditions.jl
+++ b/src/convergence/generator_conditions.jl
@@ -5,6 +5,18 @@ Base.@kwdef struct GeneratorConditionsConvergence <: AbstractConvergence
     min_success_rate::AbstractFloat = 0.75
 end
 
+function GeneratorConditionsConvergence(;
+    decision_threshold::AbstractFloat=0.5,
+    gradient_tol::AbstractFloat=1e-2,
+    max_iter::Int=100,
+    min_success_rate::AbstractFloat=0.75,
+)
+    @assert 0.0 < min_success_rate <= 1.0 "Minimum success rate should be ∈ [0.0,1.0]."
+    return GeneratorConditionsConvergence(
+        decision_threshold, gradient_tol, max_iter, min_success_rate
+    )
+end
+
 """
     converged(convergence::GeneratorConditionsConvergence, ce::CounterfactualExplanation)
 

--- a/src/counterfactuals/Counterfactuals.jl
+++ b/src/counterfactuals/Counterfactuals.jl
@@ -6,6 +6,7 @@ using .Models
 using ChainRulesCore
 using Flux
 using MLUtils
+using MultivariateStats
 using Statistics
 using StatsBase
 

--- a/src/counterfactuals/core_struct.jl
+++ b/src/counterfactuals/core_struct.jl
@@ -63,19 +63,21 @@ function CounterfactualExplanation(
         initialization,
     )
 
+    # Initialize search:
+    ce.search = Dict(
+        :iteration_count => 0,
+        :times_changed_features => zeros(size(decode_state(ce))),
+        :path => [],
+        :mutability => DataPreprocessing.mutability_constraints(data),
+    )
+
     # Initialization:
     adjust_shape!(ce)                   # adjust shape to specified number of counterfactuals
     ce.s′ = encode_state(ce)            # encode the counterfactual state
     ce.s′ = initialize_state(ce)        # initialize the counterfactual state
     ce.x′ = decode_state(ce)            # decode the counterfactual state
 
-    # Initialize search:
-    ce.search = Dict(
-        :iteration_count => 0,
-        :times_changed_features => zeros(size(decode_state(ce))),
-        :path => [ce.s′],
-        :mutability => DataPreprocessing.mutability_constraints(data),
-    )
+    push!(ce.search[:path], ce.s′)
 
     # Check for redundancy:
     if in_target_class(ce) && Convergence.threshold_reached(ce)

--- a/src/counterfactuals/core_struct.jl
+++ b/src/counterfactuals/core_struct.jl
@@ -69,6 +69,7 @@ function CounterfactualExplanation(
         :times_changed_features => zeros(size(decode_state(ce))),
         :path => [],
         :mutability => DataPreprocessing.mutability_constraints(data),
+        :potential_neighbors => find_potential_neighbors(ce),
     )
 
     # Initialization:

--- a/src/counterfactuals/core_struct.jl
+++ b/src/counterfactuals/core_struct.jl
@@ -66,10 +66,8 @@ function CounterfactualExplanation(
     # Initialize search:
     ce.search = Dict(
         :iteration_count => 0,
-        :times_changed_features => zeros(size(decode_state(ce))),
-        :path => [],
         :mutability => DataPreprocessing.mutability_constraints(data),
-        :potential_neighbors => find_potential_neighbors(ce),
+        :potential_neighbours => find_potential_neighbours(ce),
     )
 
     # Initialization:
@@ -78,7 +76,8 @@ function CounterfactualExplanation(
     ce.s′ = initialize_state(ce)        # initialize the counterfactual state
     ce.x′ = decode_state(ce)            # decode the counterfactual state
 
-    push!(ce.search[:path], ce.s′)
+    ce.search[:path] = [ce.s′]
+    ce.search[:times_changed_features] = zeros(size(decode_state(ce)))
 
     # Check for redundancy:
     if in_target_class(ce) && Convergence.threshold_reached(ce)

--- a/src/counterfactuals/core_struct.jl
+++ b/src/counterfactuals/core_struct.jl
@@ -10,8 +10,6 @@ mutable struct CounterfactualExplanation <: AbstractCounterfactualExplanation
     data::DataPreprocessing.CounterfactualData
     M::Models.AbstractFittedModel
     generator::Generators.AbstractGenerator
-    generative_model_params::NamedTuple
-    params::Dict
     search::Union{Dict,Nothing}
     convergence::AbstractConvergence
     num_counterfactuals::Int
@@ -25,15 +23,9 @@ end
 		data::CounterfactualData,
 		M::Models.AbstractFittedModel,
 		generator::Generators.AbstractGenerator,
-		max_iter::Int = 100,
 		num_counterfactuals::Int = 1,
 		initialization::Symbol = :add_perturbation,
-		generative_model_params::NamedTuple = (;),
-		min_success_rate::AbstractFloat=0.99,
         convergence::Union{AbstractConvergence,Symbol}=:decision_threshold,
-        invalidation_rate::AbstractFloat=0.5,
-        learning_rate::AbstractFloat=1.0,
-        variance::AbstractFloat=0.01,
 	)
 
 Outer method to construct a `CounterfactualExplanation` structure.
@@ -46,43 +38,16 @@ function CounterfactualExplanation(
     generator::Generators.AbstractGenerator;
     num_counterfactuals::Int=1,
     initialization::Symbol=:add_perturbation,
-    generative_model_params::NamedTuple=(;),
-    max_iter::Int=100,
-    decision_threshold::AbstractFloat=0.5,
-    gradient_tol::AbstractFloat=parameters[:τ],
-    min_success_rate::AbstractFloat=parameters[:min_success_rate],
     convergence::Union{AbstractConvergence,Symbol}=:decision_threshold,
-    invalidation_rate::AbstractFloat=0.5,
-    learning_rate::AbstractFloat=1.0,
-    variance::AbstractFloat=0.01,
 )
-
-    # Assertions:
-    @assert any(predict_label(M, data) .== target) "You model `M` never predicts the target value `target` for any of the samples contained in `data`. Are you sure the model is correctly specified?"
-    @assert 0.0 < min_success_rate <= 1.0 "Minimum success rate should be ∈ [0.0,1.0]."
+    @assert any(predict_label(M, data) .== target) "Your model `M` never predicts the target value `target` for any of the samples contained in `data`. Are you sure the model is correctly specified?"
     convergence = Convergence.get_convergence_type(convergence)
 
-    # Factual:
+    # Factual and target:
     x = typeof(x) == Int ? select_factual(data, x) : x
-
-    # Target:
     target_encoded = data.output_encoder(target)
 
-    # Initial Parameters:
-    params = Dict{Symbol,Any}(
-        :mutability => DataPreprocessing.mutability_constraints(data),
-        :latent_space => generator.latent_space,
-        :dim_reduction => generator.dim_reduction,
-        :invalidation_rate => invalidation_rate,
-        :learning_rate => learning_rate,
-        :variance => variance,
-    )
-    ids = findall(predict_label(M, data) .== target)
-    n_candidates = minimum([size(data.y, 2), 1000])
-    candidates = select_factual(data, rand(ids, n_candidates))
-    params[:potential_neighbours] = reduce(hcat, map(x -> x[1], collect(candidates)))
-
-    # Instantiate: 
+    # Instantiate:
     ce = CounterfactualExplanation(
         x,
         target,
@@ -92,8 +57,6 @@ function CounterfactualExplanation(
         data,
         M,
         deepcopy(generator),
-        generative_model_params,
-        params,
         nothing,
         convergence,
         num_counterfactuals,
@@ -101,7 +64,7 @@ function CounterfactualExplanation(
     )
 
     # Initialization:
-    adjust_shape!(ce)                                           # adjust shape to specified number of counterfactuals
+    adjust_shape!(ce)                   # adjust shape to specified number of counterfactuals
     ce.s′ = encode_state(ce)            # encode the counterfactual state
     ce.s′ = initialize_state(ce)        # initialize the counterfactual state
     ce.x′ = decode_state(ce)            # decode the counterfactual state
@@ -111,12 +74,8 @@ function CounterfactualExplanation(
         :iteration_count => 0,
         :times_changed_features => zeros(size(decode_state(ce))),
         :path => [ce.s′],
+        :mutability => DataPreprocessing.mutability_constraints(data),
     )
-
-    # This is lifted out of the above ce.search initialization because calling converged(ce) might self-reference
-    # the above fields, which are not yet initialized.
-    ce.search[:converged] = Convergence.converged(ce.convergence, ce)
-    ce.search[:terminated] = terminated(ce)
 
     # Check for redundancy:
     if in_target_class(ce) && Convergence.threshold_reached(ce)

--- a/src/counterfactuals/encodings.jl
+++ b/src/counterfactuals/encodings.jl
@@ -1,6 +1,3 @@
-using MultivariateStats
-using StatsBase
-
 """
     encode_array(dt::MultivariateStats.AbstractDimensionalityReduction, x::AbstractArray)
 
@@ -63,12 +60,12 @@ function encode_state(
     data = ce.data
 
     # Latent space:
-    if ce.params[:latent_space]
+    if ce.generator.latent_space
         s′ = map_to_latent(ce, s′)
     end
 
     # Standardize data unless latent space:
-    if !ce.params[:latent_space] && data.standardize
+    if !ce.generator.latent_space && data.standardize
         dt = data.dt
         idx = transformable_features(data)
         ChainRulesCore.ignore_derivatives() do
@@ -80,8 +77,8 @@ function encode_state(
 
     # Compress:
     if data.dt isa MultivariateStats.AbstractDimensionalityReduction &&
-        !ce.params[:latent_space] &&
-        ce.params[:dim_reduction]
+        !ce.generator.latent_space &&
+        ce.generator.dim_reduction
         s′ = encode_array(data.dt, s′)
     end
 
@@ -111,12 +108,12 @@ function decode_state(
     data = ce.data
 
     # Latent space:
-    if ce.params[:latent_space]
+    if ce.generator.latent_space
         s′ = map_from_latent(ce, s′)
     end
 
     # Standardization:
-    if !ce.params[:latent_space] && data.standardize
+    if !ce.generator.latent_space && data.standardize
         dt = data.dt
 
         # Continuous:
@@ -130,8 +127,8 @@ function decode_state(
 
     # Decompress:
     if data.dt isa MultivariateStats.AbstractDimensionalityReduction &&
-        !ce.params[:latent_space] &&
-        ce.params[:dim_reduction]
+        !ce.generator.latent_space &&
+        ce.generator.dim_reduction
         s′ = decode_array(data.dt, s′)
     end
 

--- a/src/counterfactuals/generate_counterfactual.jl
+++ b/src/counterfactuals/generate_counterfactual.jl
@@ -1,8 +1,7 @@
 # -------- Main method:
 """
 	generate_counterfactual(
-		x::Union{AbstractArray,Int}, target::RawTargetType, data::CounterfactualData, M::Models.AbstractFittedModel, generator::AbstractGenerator;
-		γ::AbstractFloat=0.75, max_iter=1000
+		x::Union{AbstractArray,Int}, target::RawTargetType, data::CounterfactualData, M::Models.AbstractFittedModel, generator::AbstractGenerator
 	)
 
 The core function that is used to run counterfactual search for a given factual `x`, target, counterfactual data, model and generator. 
@@ -48,18 +47,10 @@ function generate_counterfactual(
     generator::AbstractGenerator;
     num_counterfactuals::Int=1,
     initialization::Symbol=:add_perturbation,
-    generative_model_params::NamedTuple=(;),
-    max_iter::Int=100,
-    decision_threshold::AbstractFloat=0.5,
-    gradient_tol::AbstractFloat=parameters[:τ],
-    min_success_rate::AbstractFloat=parameters[:min_success_rate],
     convergence::Union{AbstractConvergence,Symbol}=Convergence.DecisionThresholdConvergence(;
         decision_threshold=(1 / length(data.y_levels))
     ),
     timeout::Union{Nothing,Int}=nothing,
-    invalidation_rate::AbstractFloat=0.1,
-    learning_rate::AbstractFloat=1.0,
-    variance::AbstractFloat=0.01,
 )
     # Initialize:
     ce = CounterfactualExplanation(
@@ -70,20 +61,12 @@ function generate_counterfactual(
         generator;
         num_counterfactuals=num_counterfactuals,
         initialization=initialization,
-        generative_model_params=generative_model_params,
-        max_iter=max_iter,
-        min_success_rate=min_success_rate,
-        decision_threshold=decision_threshold,
-        gradient_tol=gradient_tol,
         convergence=convergence,
-        invalidation_rate=invalidation_rate,
-        learning_rate=learning_rate,
-        variance=variance,
     )
 
     # Search:
     timer = isnothing(timeout) ? nothing : Timer(timeout)
-    while !ce.search[:terminated]
+    while !terminated(ce)
         update!(ce)
         if !isnothing(timer)
             yield()

--- a/src/counterfactuals/growing_spheres.jl
+++ b/src/counterfactuals/growing_spheres.jl
@@ -1,4 +1,3 @@
-
 function generate_counterfactual(
     x::AbstractArray,
     target::RawTargetType,
@@ -6,7 +5,6 @@ function generate_counterfactual(
     M::Models.AbstractFittedModel,
     generator::Generators.GrowingSpheresGenerator;
     num_counterfactuals::Int=1,
-    max_iter::Int=1000,
     convergence::Union{AbstractConvergence,Symbol}=Convergence.DecisionThresholdConvergence(;
         decision_threshold=(1 / length(data.y_levels)), max_iter=1000
     ),

--- a/src/counterfactuals/initialisation.jl
+++ b/src/counterfactuals/initialisation.jl
@@ -10,7 +10,6 @@ function initialize_state(ce::CounterfactualExplanation)
     @assert ce.initialization ∈ [:identity, :add_perturbation]
 
     s′ = ce.s′
-    data = ce.data
 
     # No perturbation:
     if ce.initialization == :identity
@@ -18,7 +17,7 @@ function initialize_state(ce::CounterfactualExplanation)
     end
 
     # If latent space, initial point is random anyway:
-    if ce.params[:latent_space]
+    if ce.generator.latent_space
         return s′
     end
 

--- a/src/counterfactuals/latent_space_mappings.jl
+++ b/src/counterfactuals/latent_space_mappings.jl
@@ -15,7 +15,7 @@ function map_from_latent(
     data = ce.data
 
     # Latent space:
-    if ce.params[:latent_space]
+    if ce.generator.latent_space
         generative_model = data.generative_model
         if !isnothing(generative_model)
             # NOTE! This is not very clean, will be improved.
@@ -47,9 +47,9 @@ function map_to_latent(
     data = ce.data
     generator = ce.generator
 
-    if ce.params[:latent_space]
+    if generator.latent_space
         generative_model = DataPreprocessing.get_generative_model(
-            data; ce.generative_model_params...
+            data; generator.generative_model_params...
         )
         # map counterfactual to latent space: s′=z′∼p(z|x)
         s′, _, _ = GenerativeModels.rand(generative_model.encoder, s′)
@@ -69,7 +69,7 @@ A convenience function that checks if latent space search is applicable.
 function wants_latent_space(ce::CounterfactualExplanation)
 
     # Unpack:
-    latent_space = ce.params[:latent_space]
+    latent_space = ce.generator.latent_space
 
     # If threshold is already reached, training GM is redundant:
     latent_space = latent_space && !Convergence.threshold_reached(ce)

--- a/src/counterfactuals/path_tracking.jl
+++ b/src/counterfactuals/path_tracking.jl
@@ -17,9 +17,7 @@ end
 Returns the counterfactual probabilities for each step of the search.
 """
 function counterfactual_probability_path(ce::CounterfactualExplanation)
-    M = ce.M
-    p = map(X -> counterfactual_probability(ce, X), path(ce))
-    return p
+    return map(X -> counterfactual_probability(ce, X), path(ce))
 end
 
 """

--- a/src/counterfactuals/search.jl
+++ b/src/counterfactuals/search.jl
@@ -18,7 +18,6 @@ function update!(ce::CounterfactualExplanation)
         decode_state(ce, Δs′) .!= 0, size(ce.search[:times_changed_features])
     )
     ce.search[:times_changed_features] += _times_changed        # update number of times feature has been changed
-    ce.search[:mutability] = Generators.mutability_constraints(ce.generator, ce)
     ce.search[:iteration_count] += 1                            # update iteration counter   
     ce.search[:path] = [ce.search[:path]..., ce.s′]
     return terminated(ce)

--- a/src/counterfactuals/search.jl
+++ b/src/counterfactuals/search.jl
@@ -21,8 +21,7 @@ function update!(ce::CounterfactualExplanation)
     ce.search[:mutability] = Generators.mutability_constraints(ce.generator, ce)
     ce.search[:iteration_count] += 1                            # update iteration counter   
     ce.search[:path] = [ce.search[:path]..., ce.s′]
-    ce.search[:converged] = Convergence.converged(ce.convergence, ce)
-    return ce.search[:terminated] = terminated(ce)
+    return terminated(ce)
 end
 
 """
@@ -34,7 +33,7 @@ end
 A subroutine that applies mutability constraints to the proposed vector of feature perturbations.
 """
 function apply_mutability(ce::CounterfactualExplanation, Δs′::AbstractArray)
-    if ce.params[:latent_space] ||
+    if ce.generator.latent_space ||
         ce.data.dt isa MultivariateStats.AbstractDimensionalityReduction
         if isnothing(ce.search)
             @warn "Mutability constraints not currently implemented for latent space search."
@@ -42,7 +41,7 @@ function apply_mutability(ce::CounterfactualExplanation, Δs′::AbstractArray)
         return Δs′
     end
 
-    mutability = ce.params[:mutability]
+    mutability = ce.search[:mutability]
     # Helper functions:
     both(x) = x
     increase(x) = ifelse(x < 0.0, 0.0, x)

--- a/src/counterfactuals/utils.jl
+++ b/src/counterfactuals/utils.jl
@@ -64,8 +64,6 @@ function adjust_shape!(ce::CounterfactualExplanation)
     target_encoded = ce.target_encoded
     ce.target_encoded = adjust_shape(ce, target_encoded)
 
-    # Parameters:
-    params = ce.params
-    params[:mutability] = adjust_shape(ce, params[:mutability])      # augment to account for specified number of counterfactuals
-    return ce.params = params
+    ce.search[:mutability] = adjust_shape(ce, ce.search[:mutability])      # augment to account for specified number of counterfactuals
+    return nothing
 end

--- a/src/counterfactuals/utils.jl
+++ b/src/counterfactuals/utils.jl
@@ -64,6 +64,7 @@ function adjust_shape!(ce::CounterfactualExplanation)
     target_encoded = ce.target_encoded
     ce.target_encoded = adjust_shape(ce, target_encoded)
 
-    ce.search[:mutability] = adjust_shape(ce, ce.search[:mutability])      # augment to account for specified number of counterfactuals
-    return ce.search
+    search = ce.search
+    search[:mutability] = adjust_shape(ce, search[:mutability])      # augment to account for specified number of counterfactuals
+    return ce.search = search
 end

--- a/src/counterfactuals/utils.jl
+++ b/src/counterfactuals/utils.jl
@@ -74,10 +74,10 @@ end
 
 Finds potential neighbors for the selected factual data point.
 """
-function find_potential_neighbors(ce::AbstractCounterfactualExplanation)
+function find_potential_neighbours(ce::AbstractCounterfactualExplanation)
     ids = findall(Models.predict_label(ce.M, ce.data) .== ce.target)
     n_candidates = minimum([size(ce.data.y, 2), 1000])
     candidates = DataPreprocessing.select_factual(ce.data, rand(ids, n_candidates))
-    potential_neighbors = reduce(hcat, map(x -> x[1], collect(candidates)))
-    return potential_neighbors
+    potential_neighbours = reduce(hcat, map(x -> x[1], collect(candidates)))
+    return potential_neighbours
 end

--- a/src/counterfactuals/utils.jl
+++ b/src/counterfactuals/utils.jl
@@ -65,5 +65,5 @@ function adjust_shape!(ce::CounterfactualExplanation)
     ce.target_encoded = adjust_shape(ce, target_encoded)
 
     ce.search[:mutability] = adjust_shape(ce, ce.search[:mutability])      # augment to account for specified number of counterfactuals
-    return nothing
+    return ce.search
 end

--- a/src/counterfactuals/utils.jl
+++ b/src/counterfactuals/utils.jl
@@ -68,3 +68,16 @@ function adjust_shape!(ce::CounterfactualExplanation)
     search[:mutability] = adjust_shape(ce, search[:mutability])      # augment to account for specified number of counterfactuals
     return ce.search = search
 end
+
+"""
+    find_potential_neighbors(ce::AbstractCounterfactualExplanation)
+
+Finds potential neighbors for the selected factual data point.
+"""
+function find_potential_neighbors(ce::AbstractCounterfactualExplanation)
+    ids = findall(Models.predict_label(ce.M, ce.data) .== ce.target)
+    n_candidates = minimum([size(ce.data.y, 2), 1000])
+    candidates = DataPreprocessing.select_factual(ce.data, rand(ids, n_candidates))
+    potential_neighbors = reduce(hcat, map(x -> x[1], collect(candidates)))
+    return potential_neighbors
+end

--- a/src/generators/gradient_based/base.jl
+++ b/src/generators/gradient_based/base.jl
@@ -16,6 +16,7 @@ mutable struct GradientBasedGenerator <: AbstractGradientBasedGenerator
     latent_space::Bool
     dim_reduction::Bool
     opt::Flux.Optimise.AbstractOptimiser
+    generative_model_params::NamedTuple
 end
 
 """
@@ -25,6 +26,7 @@ end
 		λ::Union{Nothing,AbstractFloat,Vector{AbstractFloat}}=nothing,
 		latent_space::Bool::false,
 		opt::Flux.Optimise.AbstractOptimiser=Flux.Descent(),
+        generative_model_params::NamedTuple=(;),
 	)
 
 Default outer constructor for `GradientBasedGenerator`.
@@ -35,6 +37,7 @@ Default outer constructor for `GradientBasedGenerator`.
 - `λ::Union{Nothing,AbstractFloat,Vector{AbstractFloat}}=nothing`: The weight of the penalty function.
 - `latent_space::Bool=false`: Whether to use the latent space of a generative model to generate counterfactuals.
 - `opt::Flux.Optimise.AbstractOptimiser=Flux.Descent()`: The optimizer to use for the generator.
+- `generative_model_params::NamedTuple`: The parameters of the generative model associated with the generator.
 
 # Returns
 - `generator::GradientBasedGenerator`: A gradient-based counterfactual generator.
@@ -46,6 +49,7 @@ function GradientBasedGenerator(;
     latent_space::Bool=false,
     dim_reduction::Bool=false,
     opt::Flux.Optimise.AbstractOptimiser=Flux.Descent(),
+    generative_model_params::NamedTuple=(;),
 )
     @assert !(isnothing(λ) && !isnothing(penalty)) "Penalty function(s) provided but no penalty weight(s) provided."
     @assert !(isnothing(λ) && !isnothing(penalty)) "Penalty weight(s) provided but no penalty function(s) provided."
@@ -53,7 +57,9 @@ function GradientBasedGenerator(;
         @assert length(λ) == length(penalty) || length(λ) == 1 "The number of penalty weights must match the number of penalty functions or be equal to one."
         length(λ) == 1 && (λ = fill(λ[1], length(penalty)))     # if only one penalty weight is provided, use it for all penalties
     end
-    return GradientBasedGenerator(loss, penalty, λ, latent_space, dim_reduction, opt)
+    return GradientBasedGenerator(
+        loss, penalty, λ, latent_space, dim_reduction, opt, generative_model_params
+    )
 end
 
 """

--- a/src/generators/gradient_based/utils.jl
+++ b/src/generators/gradient_based/utils.jl
@@ -22,19 +22,6 @@ function _replace_nans(Δs′::AbstractArray, old_new::Pair=(NaN => 0))
 end
 
 """
-    mutability_constraints(generator::AbstractGradientBasedGenerator, ce::AbstractCounterfactualExplanation)
-
-The default method to return mutability constraints that are dependent on the current counterfactual search state.
-For generic gradient-based generators, no state-dependent constraints are added.
-"""
-function mutability_constraints(
-    generator::AbstractGenerator, ce::AbstractCounterfactualExplanation
-)
-    mutability = ce.params[:mutability]
-    return mutability # no additional constraints for GenericGenerator
-end
-
-"""
     conditions_satisfied(generator::AbstractGradientBasedGenerator, ce::AbstractCounterfactualExplanation)
 
 The default method to check if the all conditions for convergence of the counterfactual search have been satisified for gradient-based generators.

--- a/src/generators/non_gradient_based/growing_spheres/growing_spheres.jl
+++ b/src/generators/non_gradient_based/growing_spheres/growing_spheres.jl
@@ -152,9 +152,6 @@ function feature_selection!(ce::AbstractCounterfactualExplanation)
     end
 
     ce.s′ = counterfactual″
-    ce.search[:terminated] = true
-    ce.search[:converged] = true
-
     return nothing
 end
 

--- a/src/global_utils.jl
+++ b/src/global_utils.jl
@@ -3,10 +3,6 @@ using Flux
 using MLJBase
 using Parameters
 
-# Global constants:
-"A container for global parameters."
-const parameters = Dict(:τ => 1e-2, :min_success_rate => 0.75)
-
 # Abstract Base Types:
 """
     RawTargetType

--- a/src/objectives/Objectives.jl
+++ b/src/objectives/Objectives.jl
@@ -1,6 +1,8 @@
 module Objectives
 
 using ..CounterfactualExplanations
+using ..Models
+using ..DataPreprocessing
 using Flux
 using Flux.Losses
 using ChainRulesCore

--- a/src/objectives/Objectives.jl
+++ b/src/objectives/Objectives.jl
@@ -1,8 +1,6 @@
 module Objectives
 
 using ..CounterfactualExplanations
-using ..Models
-using ..DataPreprocessing
 using Flux
 using Flux.Losses
 using ChainRulesCore

--- a/src/objectives/distance_utils.jl
+++ b/src/objectives/distance_utils.jl
@@ -37,23 +37,11 @@ end
 Computes the distance of the counterfactual from a point in the target main.
 """
 function distance_from_target(ce::AbstractCounterfactualExplanation; K::Int=50, kwrgs...)
-    if !(:potential_neighbors ∈ collect(keys(ce.search)))
-        ce.search[:potential_neighbors] = find_potential_neighbors(ce)
-    end
-
     ids = rand(1:size(ce.search[:potential_neighbors], 2), K)
     neighbours = ce.search[:potential_neighbors][:, ids]
     centroid = Statistics.mean(neighbours; dims=ndims(neighbours))
     Δ = distance(ce; from=centroid, kwrgs...)
     return Δ
-end
-
-function find_potential_neighbors(ce::AbstractCounterfactualExplanation)
-    ids = findall(Models.predict_label(ce.M, ce.data) .== ce.target)
-    n_candidates = minimum([size(ce.data.y, 2), 1000])
-    candidates = DataPreprocessing.select_factual(ce.data, rand(ids, n_candidates))
-    potential_neighbors = hcat([x[1] for x in candidates]...)
-    return potential_neighbors
 end
 
 """

--- a/src/objectives/distance_utils.jl
+++ b/src/objectives/distance_utils.jl
@@ -37,8 +37,8 @@ end
 Computes the distance of the counterfactual from a point in the target main.
 """
 function distance_from_target(ce::AbstractCounterfactualExplanation; K::Int=50, kwrgs...)
-    ids = rand(1:size(ce.search[:potential_neighbors], 2), K)
-    neighbours = ce.search[:potential_neighbors][:, ids]
+    ids = rand(1:size(ce.search[:potential_neighbours], 2), K)
+    neighbours = ce.search[:potential_neighbours][:, ids]
     centroid = Statistics.mean(neighbours; dims=ndims(neighbours))
     Δ = distance(ce; from=centroid, kwrgs...)
     return Δ

--- a/src/objectives/distance_utils.jl
+++ b/src/objectives/distance_utils.jl
@@ -30,15 +30,20 @@ end
 
 """
     distance_from_target(
-        ce::AbstractCounterfactualExplanation, p::Int=2; 
-        agg=mean, K::Int=50
+        ce::AbstractCounterfactualExplanation;
+        K::Int=50
     )
 
 Computes the distance of the counterfactual from a point in the target main.
 """
 function distance_from_target(ce::AbstractCounterfactualExplanation; K::Int=50, kwrgs...)
-    ids = rand(1:size(ce.params[:potential_neighbours], 2), K)
-    neighbours = ce.params[:potential_neighbours][:, ids]
+    ids = findall(Models.predict_label(ce.M, ce.data) .== ce.target)
+    n_candidates = minimum([size(ce.data.y, 2), 1000])
+    candidates = DataPreprocessing.select_factual(ce.data, rand(ids, n_candidates))
+    potential_neighbors = reduce(hcat, map(x -> x[1], collect(candidates)))
+
+    ids = rand(1:size(potential_neighbors, 2), K)
+    neighbours = potential_neighbors[:, ids]
     centroid = Statistics.mean(neighbours; dims=ndims(neighbours))
     Δ = distance(ce; from=centroid, kwrgs...)
     return Δ

--- a/src/objectives/distance_utils.jl
+++ b/src/objectives/distance_utils.jl
@@ -37,16 +37,23 @@ end
 Computes the distance of the counterfactual from a point in the target main.
 """
 function distance_from_target(ce::AbstractCounterfactualExplanation; K::Int=50, kwrgs...)
+    if !(:potential_neighbors ∈ collect(keys(ce.search)))
+        ce.search[:potential_neighbors] = find_potential_neighbors(ce)
+    end
+
+    ids = rand(1:size(ce.search[:potential_neighbors], 2), K)
+    neighbours = ce.search[:potential_neighbors][:, ids]
+    centroid = Statistics.mean(neighbours; dims=ndims(neighbours))
+    Δ = distance(ce; from=centroid, kwrgs...)
+    return Δ
+end
+
+function find_potential_neighbors(ce::AbstractCounterfactualExplanation)
     ids = findall(Models.predict_label(ce.M, ce.data) .== ce.target)
     n_candidates = minimum([size(ce.data.y, 2), 1000])
     candidates = DataPreprocessing.select_factual(ce.data, rand(ids, n_candidates))
     potential_neighbors = reduce(hcat, map(x -> x[1], collect(candidates)))
-
-    ids = rand(1:size(potential_neighbors, 2), K)
-    neighbours = potential_neighbors[:, ids]
-    centroid = Statistics.mean(neighbours; dims=ndims(neighbours))
-    Δ = distance(ce; from=centroid, kwrgs...)
-    return Δ
+    return potential_neighbors
 end
 
 """

--- a/src/objectives/distance_utils.jl
+++ b/src/objectives/distance_utils.jl
@@ -52,7 +52,7 @@ function find_potential_neighbors(ce::AbstractCounterfactualExplanation)
     ids = findall(Models.predict_label(ce.M, ce.data) .== ce.target)
     n_candidates = minimum([size(ce.data.y, 2), 1000])
     candidates = DataPreprocessing.select_factual(ce.data, rand(ids, n_candidates))
-    potential_neighbors = reduce(hcat, map(x -> x[1], collect(candidates)))
+    potential_neighbors = hcat([x[1] for x in candidates]...)
     return potential_neighbors
 end
 

--- a/src/objectives/penalties.jl
+++ b/src/objectives/penalties.jl
@@ -9,7 +9,7 @@ function distance_mad(
     X = ce.data.X
     mad = []
     ChainRulesCore.ignore_derivatives() do
-        _dict = ce.params
+        _dict = ce.search
         if !(:mad_features ∈ collect(keys(_dict)))
             X̄ = Statistics.median(X; dims=ndims(X))
             _mad = Statistics.median(abs.(X .- X̄); dims=ndims(X))

--- a/test/generators/clue.jl
+++ b/test/generators/clue.jl
@@ -40,7 +40,7 @@ using Random
 
                     @testset "Predetermined outputs" begin
                         if generator.latent_space
-                            @test counterfactual.params[:latent_space]
+                            @test counterfactual.generator.latent_space
                         end
                         @test counterfactual.target == target
                         @test counterfactual.x == x &&

--- a/test/generators/counterfactuals.jl
+++ b/test/generators/counterfactuals.jl
@@ -53,7 +53,7 @@ for (key, generator_) in generators
 
                             @testset "Predetermined outputs" begin
                                 if generator.latent_space
-                                    @test counterfactual.params[:latent_space]
+                                    @test counterfactual.generator.latent_space
                                 end
                                 @test counterfactual.target == target
                                 @test counterfactual.x == x &&

--- a/test/models/pretrained.jl
+++ b/test/models/pretrained.jl
@@ -40,7 +40,7 @@ if VERSION >= v"1.8"
 
                         @testset "Predetermined outputs" begin
                             if generator.latent_space
-                                @test counterfactual.params[:latent_space]
+                                @test counterfactual.generator.latent_space
                             end
                             @test counterfactual.target == target
                             @test counterfactual.x == x &&


### PR DESCRIPTION
As the next refactoring step, I've implemented the following changes:

- Remove keyword arguments that became redundant after #372.
- Move the `generative_model_params` keyword argument out from the `CounterfactualExplanation` struct and define it as a keyword argument of the `GradientBasedGenerator` struct instead, since it's only related to the generators.
- Remove the `params` dictionary from the core struct. This dictionary seemed redundant to me: the `:invalidation_rate`, `:variance` and `:learning_rate` keys had become redundant through the creation of the `Convergence` module; for `:latent_space` and `:dim_reduction`, it's clearer and more straightforward to just always call `generator.latent_space` and `generator.dim_reduction` instead. The `:mutability` key was stored both in `params` and `search` anyways, so can just as well only be stored in `search`. This leaves only the `:potential_neighbors` and `:mad_features` keys - though their fit in `search` is not that natural, I don't think the `params` dict is worth keeping only for these two keys, so I moved them over to `search` as well.
- Remove the `:converged` and `:terminated` keys from the `search` dictionary: instead, it's cleaner to just always call the `converged()` and `terminated()` methods.