### PR TITLE
475 no method matching for neurotreemodel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## Version [1.3.1] - 2024-09-24
 
+### Changed
+
+- Fixed a remaining bug in `NeuroTreeExt` extensions. [#475]
+
 ## Version [1.3.0] - 2024-09-16
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 *Note*: We try to adhere to these practices as of version [v1.1.1].
 
+## Version [1.3.1] - 2024-09-24
+
 ## Version [1.3.0] - 2024-09-16
 
 ### Changed

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CounterfactualExplanations"
 uuid = "2f13d31b-18db-44c1-bc43-ebaf2cff0be0"
-authors = ["Patrick Altmeyer <p.altmeyer@tudelft.nl>"]
-version = "1.3.0"
+authors = ["Patrick Altmeyer <p.altmeyer@tudelft.nl> and contributors"]
+version = "1.3.1"
 
 [deps]
 CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"

--- a/ext/NeuroTreeExt/neurotree.jl
+++ b/ext/NeuroTreeExt/neurotree.jl
@@ -83,7 +83,7 @@ logits = Models.logits(M, x) # calculates the logit scores for each output class
 function Models.logits(
     M::Models.Model, type::CounterfactualExplanations.NeuroTreeModel, X::AbstractArray
 )
-    X = X[:, :]
+    X = X[:, :] |> x -> convert.(eltype(Flux.params(M.fitresult().chain)[1]), x)
     return M.fitresult(X)
 end
 

--- a/test/models/neurotree/neurotree.jl
+++ b/test/models/neurotree/neurotree.jl
@@ -18,8 +18,9 @@ using TaijaData
     )
 
     # Predictions:
-    yhat = logits(M, data.X)        # matrix
-    yhat = logits(M, data.X[:, 1])  # vector
+    yhat = logits(M, data.X)                    # matrix
+    yhat = logits(M, data.X[:, 1])              # vector
+    yhat = logits(M, Float64.(data.X[:, 1]))    # vector with different eltype
 
     # Select a factual instance:
     target = 2


### PR DESCRIPTION
@abuszydlik your hunch was right and this should do it now. 

Not the most elegant way to infer the element type of the underlying `Flux.Chain` but not really sure how else to address this. 

@jeremiedb how are you doing? Hope the remainder of your Eurotrip was fun! Is there a better way to infer the element type of the weights `W` of the underlying `NeuroTree{W, ...}`? I'll merge this as soon as tests pass, so @abuszydlik can continue his work, but would much appreciate your thoughts if any. Thanks!