### PR TITLE
Add gradient preparation to invalidation rate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 *Note*: We try to adhere to these practices as of version [v1.1.1].
 
+## Version [1.5.1] - 2026-02-18
+
+### Changed
+
+- Using prepared gradient for invalidation rate. 
+
 ## Version [1.5.0] - 2026-02-14
 
 ### Breaking

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "CounterfactualExplanations"
 uuid = "2f13d31b-18db-44c1-bc43-ebaf2cff0be0"
-version = "1.5.0"
+version = "1.5.1"
 authors = ["Patrick Altmeyer <p.altmeyer@tudelft.nl> and contributors"]
 
 [deps]

--- a/src/convergence/invalidation_rate.jl
+++ b/src/convergence/invalidation_rate.jl
@@ -57,7 +57,7 @@ function invalidation_rate(ce_state::AbstractArray, ce::AbstractCounterfactualEx
     prep = get!(ce.search, :prep_inval, DI.prepare_gradient(f, backend, similar(ce_state)))
 
     # Compute gradient:
-    grad = DI.gradient(f, prep, backend)
+    grad = DI.gradient(f, prep, backend, ce_state)
     denominator = sqrt(ce.convergence.variance) * norm(grad)
     normalized_gradient = f_loss / denominator
     ϕ = Distributions.cdf(Distributions.Normal(0, 1), normalized_gradient)

--- a/src/convergence/invalidation_rate.jl
+++ b/src/convergence/invalidation_rate.jl
@@ -29,6 +29,23 @@ function converged(
 end
 
 """
+    logit_target(x::AbstractArray, ce::AbstractCounterfactualExplanation)
+
+Compute the logit value for the target class of a counterfactual explanation.
+
+Parameters:
+- `x`: The input data point.
+- `ce`: The counterfactual explanation object containing model and target information.
+
+Returns:
+- The logit value for the target class specified in the counterfactual explanation.
+"""
+function logit_target(x::AbstractArray, ce::AbstractCounterfactualExplanation)
+    index_target = get_target_index(ce.data.y_levels, ce.target)
+    return logits(ce.M, CounterfactualExplanations.decode_state(ce, x))[index_target]
+end
+
+"""
     invalidation_rate(ce::AbstractCounterfactualExplanation)
 
 Calculates the invalidation rate of a counterfactual explanation.
@@ -41,23 +58,25 @@ Calculates the invalidation rate of a counterfactual explanation.
 The invalidation rate of the counterfactual explanation.
 """
 function invalidation_rate(ce_state::AbstractArray, ce::AbstractCounterfactualExplanation)
+
+    # Compute numerator:
     index_target = get_target_index(ce.data.y_levels, ce.target)
     f_loss = logits(ce.M, CounterfactualExplanations.decode_state(ce))[index_target]
-    y = ce.target_encoded
-
-    # Create closure
-    function f(x)
-        return logits(ce.M, CounterfactualExplanations.decode_state(ce, x))[index_target]
-    end
 
     # Get AD backend:
     backend = get!(ce.search, :ad_backend, CounterfactualExplanations.choose_ad_backend(ce))
 
     # Get prepared gradient:
-    prep = get!(ce.search, :prep_inval, DI.prepare_gradient(f, backend, similar(ce_state)))
+    prep = get!(
+        ce.search,
+        :prep_inval,
+        DI.prepare_gradient(logit_target, backend, similar(ce_state), DI.Constant(ce)),
+    )
 
     # Compute gradient:
-    grad = DI.gradient(f, prep, backend, ce_state)
+    grad = DI.gradient(logit_target, prep, backend, ce_state, DI.Constant(ce))
+
+    # Final IR computation:
     denominator = sqrt(ce.convergence.variance) * norm(grad)
     normalized_gradient = f_loss / denominator
     ϕ = Distributions.cdf(Distributions.Normal(0, 1), normalized_gradient)

--- a/src/convergence/invalidation_rate.jl
+++ b/src/convergence/invalidation_rate.jl
@@ -50,8 +50,14 @@ function invalidation_rate(ce_state::AbstractArray, ce::AbstractCounterfactualEx
         return logits(ce.M, CounterfactualExplanations.decode_state(ce, x))[index_target]
     end
 
+    # Get AD backend:
+    backend = get!(ce.search, :ad_backend, CounterfactualExplanations.choose_ad_backend(ce))
+
+    # Get prepared gradient:
+    prep = get!(ce.search, :prep_inval, DI.prepare_gradient(f, backend, similar(ce_state)))
+
     # Compute gradient:
-    grad = DI.gradient(f, get_global_ad_backend(), ce_state)
+    grad = DI.gradient(f, prep, backend)
     denominator = sqrt(ce.convergence.variance) * norm(grad)
     normalized_gradient = f_loss / denominator
     ϕ = Distributions.cdf(Distributions.Normal(0, 1), normalized_gradient)


### PR DESCRIPTION
@gdalle I've tried what you suggested in #518, but the prepared gradient doesn't match the executed gradient:

```
/home/runner/work/CounterfactualExplanations.jl/CounterfactualExplanations.jl/test/generators/probe.jl:19
  Got exception outside of a @test
  PreparationMismatchError (inconsistent types between preparation and execution):
    - f: ✅
    - backend: ✅
    - x: ❌
      - prep: Matrix{Float32}
      - exec: Matrix{ForwardDiff.Dual{ForwardDiff.Tag{typeof(CounterfactualExplanations.Generators.pen_wrt_state), Float32}, Float32, 2}}
    - contexts: ✅
  If you are confident that this check is superfluous, you can disable it by running preparation with the keyword argument `strict=Val(false)` inside DifferentiationInterface.
```
 
Any idea what be going on? Note that this gradient computation is nested inside another gradient computation - perhaps that's the issue? 